### PR TITLE
Handle 'leveled' moves

### DIFF
--- a/GGStriveUtilsBot/Utils/FrameDataEmbedBuilder.cs
+++ b/GGStriveUtilsBot/Utils/FrameDataEmbedBuilder.cs
@@ -17,7 +17,17 @@ namespace GGStriveUtilsBot.Utils
 
         public static async Task<DiscordEmbed> selectEmbed(DiscordClient client, DiscordUser user, DiscordChannel channel, string Move)
         {
-            (Character? character, string move, bool isNumpad) = Utils.InputParser.parseFrameDataInput(Move);
+            (Character? character, string move, string level, bool isNumpad) = Utils.InputParser.parseFrameDataInput(Move);
+
+            // Use the level to modify move if applicable
+            if (level.Length > 0 && isNumpad) {
+                move = move + " " + level;
+#if DEBUG
+                Console.WriteLine("Final Move: " + move);
+#endif
+            }
+
+
 
             var results = DustloopDataFetcher.fetchMove(character, move, isNumpad);
             var interactivity = client.GetInteractivity();

--- a/GGStriveUtilsBot/Utils/InputParser.cs
+++ b/GGStriveUtilsBot/Utils/InputParser.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
 using DSharpPlus.SlashCommands;
 
-namespace GGStriveUtilsBot.Utils
-{
-    static class InputParser
-    {
+namespace GGStriveUtilsBot.Utils {
+    static class InputParser {
         // Part of regex that captures both shortened and full names
         static private string charaPattern = String.Join(
             "",
@@ -31,8 +31,9 @@ namespace GGStriveUtilsBot.Utils
         // Part of regex that captures either move names or numpad notated moves
         static private string movePattern = String.Join(
             "",
-            @"((?<literal>(([a-z]*\s*)*)$)|",
-            @"(?<numpad>(([cfj]|(bt))?\.?\d*(\]|\[)?\d?(p|k|s|hs?|d)?(\]|\[)?\d?\s*)*$))"
+            @"((?<literal>(([a-z]*\s*)*))|",
+            @"(?<numpad>(([cfj]|(bt))?\.?\d*(\]|\[)?\d?(p|k|s|hs?|d)?(\]|\[)?\d?\s*)*))",
+            @"(?<level>((Level\s(1|2|3|(br)){1})|([2468]{3}))?$)"
         );
         static private string charaMovePattern = String.Join("", charaPattern, movePattern);
 
@@ -42,18 +43,21 @@ namespace GGStriveUtilsBot.Utils
         static private Regex prefixMoveRegex = new Regex(@"^(j|bt)\d{0,6}(p|k|s|hs?|d)|(c|f)s{1,3}$",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static (Character? character, string move, bool isNumpad) parseFrameDataInput(string input) {
+        // Returns the Character enum, move name string, move level string, and a bool indicating numpad format
+        public static (Character? character, string move, string level, bool isNumpad) parseFrameDataInput(string input) {
             MatchCollection matches = charaMoveRegex.Matches(input);
             if (matches.Count == 0) {
-                return (null, "Unknown", false);
+#if DEBUG
+                Console.WriteLine("\nUnable to parse.");
+#endif
+                return (null, "Unknown", "", false);
             }
 
             Match match = matches[0];
             GroupCollection groups = match.Groups;
 
             Character? character = null;
-            foreach (var v in Enum.GetValues(typeof(Character)))
-            {
+            foreach (var v in Enum.GetValues(typeof(Character))) {
                 if (groups[v.ToString()].Length > 0) {
                     character = (Character)Enum.Parse(typeof(Character), v.ToString());
                 }
@@ -64,6 +68,11 @@ namespace GGStriveUtilsBot.Utils
             // denotes a move in numpad notation ("236P")
             var numpad = groups["numpad"].Value.ToString().ToLower();
             numpad = numpad.Replace("hs", "h");
+            // denotes the "level" modifier for certain moves such as,
+            // Goldlewis 214S Levels 1/2/3, Nago 5H Levels 1/2/3
+            // Also used to denote Behemoth Typhoon shorthand half-circle notation
+            // For example, behemoth typhoon "426" referring to the 41236 variation
+            var level = groups["level"].Value.ToString().ToLower();
 
             string move = numpad.Length > literal.Length ? numpad : literal;
             bool isNumpad = numpad.Length > literal.Length;
@@ -79,11 +88,55 @@ namespace GGStriveUtilsBot.Utils
                 }
             }
 
+            // Special exceptions and corrections for common shorthand notations
+            // Assumes "level 1" for moves that have varying levels belonging to Nago/Goldlewis
+            // Assumes 214[k] for Zato's "Break the Law" move
+            if (character.HasValue) {
+                if (character == Character.Nago && level.Length == 0) {
+                    List<String> levelMoves = new List<string>(){
+                        "j.h", "2h", "6h", "5h"
+                    };
+                    if (levelMoves.Any(s => s.Equals(move))) {
+                        level = "level 1";
+                    }
+                } else if (character == Character.Goldlewis && level.Length == 0) {
+                    List<String> levelMoves = new List<string>() {
+                        "thunderbird", "skyfish", "burn it down", "down with the system",
+                        "214s", "236s", "236236k", "632146p"
+                    };
+                    if (levelMoves.Any(s => s.Equals(move))) {
+                        level = "level 1";
+                    }
+                } else if (character == Character.Zato) {
+                    if (move.Trim().Equals("214k")) {
+                        move = "214[k]";
+                    }
+                }
+            } 
+            else if (level.Length == 0) {
+                List<String> levelMoves = new List<string>() {
+                    "thunderbird", "skyfish", "burn it down", "down with the system"
+                };
+                if (levelMoves.Any(s => s.Equals(move))) {
+                    level = "level 1";
+                }
+            }
+
+            move = move.Trim();
+            level = level.Trim();
+
             // If for some reason a user enters numpad notation without a character,
             // this *CAN* be parsed, but should fail further down the line when fetching moves.
             // (We have no way to know which "5K" in the game they're referring to, for example)
 
-            return (character, move, isNumpad);
+#if DEBUG
+            Console.WriteLine("\nCharacter: " + character.ToString());
+            Console.WriteLine("Move: " + move);
+            Console.WriteLine("Move Level: " + level);
+            Console.WriteLine("IsNumpad: " + isNumpad.ToString());
+#endif
+
+            return (character, move, level, isNumpad);
         }
     }
 }


### PR DESCRIPTION
Also adds some common shorthand corrections related to move level & zato's "break the law"